### PR TITLE
adding -P to df to account for long device names

### DIFF
--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -153,7 +153,7 @@ class Chef
         compatible_filesystems = %w(xfs ext4)
         parent_directory = ::File.dirname(@new_resource.path)
         # Get FS info, get second line as first is column headings
-        command = "df -T #{parent_directory} | awk 'NR==2 {print $2}'"
+        command = "df -PT #{parent_directory} | awk 'NR==2 {print $2}'"
         result = shell_out(command).stdout
         Chef::Log.debug("#{@new_resource} filesystem listing is '#{result}'")
         compatible_filesystems.any? { |fs| result.include? fs }


### PR DESCRIPTION
The df command needs a -P to make sure your awk works correctly.
jpmbp: ~ ⇒  df -T /mnt
Filesystem           Type  Size  Used Avail Use% Mounted on
/dev/mapper/vg--data-ephemeral0
                     ext4  1.7T   33G  1.6T   3% /mnt
jpmbp: ~ ⇒  df -T /mnt | awk 'NR==2 {print $2}'

jpmbp: ~ ⇒  df -PT /mnt | awk 'NR==2 {print $2}'
ext4
jpmbp: ~ ⇒ df -PT /mnt
Filesystem                      Type  Size  Used Avail Use% Mounted on
/dev/mapper/vg--data-ephemeral0 ext4  1.7T   33G  1.6T   3% /mnt
jpmbp: ~ ⇒