### PR TITLE
Fix Chef 12.4.0 support

### DIFF
--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -22,6 +22,9 @@ class Chef
     class SwapFile < Chef::Provider
       include Chef::Mixin::ShellOut
 
+      # Fix Chef 12.4.0 support (issue #22)
+      provides :swap_file if Chef::Provider.respond_to?(:provides)
+
       def load_current_resource
         @current_resource ||= Chef::Resource::SwapFile.new(new_resource.name)
         @current_resource.path(new_resource.path)


### PR DESCRIPTION
Hi @sethvargo,

This is a simple patch to fix Chef `12.4.0` support. This new Chef release produces the following error with this cookbook:

```
Recipe: fake::create
  * swap_file[/mnt/swap] action create
    
    ================================================================================
    Error executing action `create` on resource 'swap_file[/mnt/swap]'
    ================================================================================
    
    ArgumentError
    -------------
    Cannot find a provider for swap_file[/mnt/swap] on ubuntu version 12.04
    
    Resource Declaration:
    ---------------------
    # In /tmp/kitchen/cookbooks/fake/recipes/create.rb
    
      1: swap_file '/mnt/swap' do
      2:   size 1
      3: end

    Compiled Resource:
    ------------------
    # Declared in /tmp/kitchen/cookbooks/fake/recipes/create.rb:1:in `from_file'
    
    swap_file("/mnt/swap") do
      action :create
      retries 0
  retry_delay 2
      default_guard_interpreter :default
      declared_type :swap_file
      cookbook_name :fake
      recipe_name "create"
      size 1
    end
    

Running handlers:
[2015-07-01T17:55:01+00:00] ERROR: Running exception handlers
Running handlers complete


[2015-07-01T17:55:01+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
[2015-07-01T17:55:01+00:00] ERROR: swap_file[/mnt/swap] (fake::create line 1) had an error: ArgumentError: Cannot find a provider for swap_file[/mnt/swap] on ubuntu version 12.04
[2015-07-01T17:55:01+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

The conditional is for Chef `11` support.

Related issue: #22